### PR TITLE
feat: add shutdown route

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 PORT=8000
 SECRET=xxxx
 APP_ORIGIN="https://some.host.com"
+SHUTDOWNABLE=1
 PRINTER_NAME="awesome printer"

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function handleRequest(request, response) {
 
 function handleShutdown(response) {
   response.end(JSON.stringify({message: "Raspi is being shut down ..."}));
-  exec("sudo shutdown -h now");
+  exec("shutdown -h now");
 }
 
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function handleRequest(request, response) {
 
     switch (request.url) {
       case "/shutdown":
-        handleShutdown(response)
+        process.env.SHUTDOWNABLE == "1" && handleShutdown(response)
         break
       default:
         handlePrinting(requestBody, response)

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function handleRequest(request, response) {
 
 function handleShutdown(response) {
   response.end(JSON.stringify({message: "Raspi is being shut down ..."}));
-  exec("shutdown -h now");
+  exec("sudo shutdown -h now");
 }
 
 

--- a/index.js
+++ b/index.js
@@ -41,41 +41,52 @@ function handleRequest(request, response) {
   request.on('data', (chunk) => {
     body.push(chunk);
   }).on('end', () => {
-    const json = Buffer.concat(body).toString();
+    const requestBody = Buffer.concat(body).toString();
 
-    try {
-      const { message } = JSON.parse(json);
-      console.log(message);
-      handlePrinting(message, response);
-    } catch (error) {
-      response.statusCode = 500;
-      response.end();
+    switch (request.url) {
+      case "/shutdown":
+        handleShutdown(response)
+        break
+      default:
+        handlePrinting(requestBody, response)
     }
   })
 }
 
+function handleShutdown(response) {
+  response.end(JSON.stringify({message: "Raspi is being shut down ..."}));
+  exec("sudo shutdown -h now");
+}
 
-function handlePrinting(idea, response) {
-  const printingCommand = getPrintingCommand(idea);
 
-  exec(printingCommand, (error, stdout, stderr) => {
-    if (error) {
-      console.error(error);
-      response.statusCode = 500;
-      response.end('error');
-      return;
-    }
+function handlePrinting(requestBody, response) {
+  try {
+    const { message } = JSON.parse(requestBody);
+      
+    const printingCommand = getPrintingCommand(message);
 
-    if (stderr) {
-      console.error(stderr);
-      response.statusCode = 500;
-      response.end('stderr');
-      return;
-    }
-
-    response.statusCode = 200;
-    response.end('success');
-  });
+    exec(printingCommand, (error, stdout, stderr) => {
+      if (error) {
+        console.error(error);
+        response.statusCode = 500;
+        response.end('error');
+        return;
+      }
+  
+      if (stderr) {
+        console.error(stderr);
+        response.statusCode = 500;
+        response.end('stderr');
+        return;
+      }
+  
+      response.statusCode = 200;
+      response.end('success');
+    });
+  } catch (error) {
+    response.statusCode = 500;
+    response.end();
+  }
 }
 
 function getPrintingCommand(idea) {


### PR DESCRIPTION
This PR makes the server react to a POST to `/shutdown`. This route is used for remotely shutting down the Raspi gracefully and safely. As with all routes, a token is required and a CORS rule is active. We do this by executing the system command `shutdown -h now`. This makes sure that all running processes are shut down correctly and the Raspi itself is shut down gracefully at the end (thanks to @Esshahn for the idea).

---

Related PRs in the web app repo:

- https://github.com/technologiestiftung/idea-machine/pull/49
- https://github.com/technologiestiftung/idea-machine/pull/50