### PR TITLE
feat: bring back auto key press to confirm HTTP Auth

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,22 @@
 const { exec } = require("child_process");
 require('dotenv').config();
 
+setTimeout(() => {
+    exec('xdotool key Return', (error, stdout, stderr) => {
+      if (error) {
+        console.error(error);
+        return;
+      }
+  
+      if (stderr) {
+        console.error(stderr);
+        return;
+      }
+  
+      console.log('successfully pressed enter');
+    })
+  }, 10_000)
+
 exec(`chromium-browser ${process.env.APP_ORIGIN} --start-fullscreen`,
     (error, stdout, stderr) => {
         if (error) {

--- a/browser.js
+++ b/browser.js
@@ -15,7 +15,7 @@ setTimeout(() => {
   
       console.log('successfully pressed enter');
     })
-  }, 10_000)
+  }, 20_000)
 
 exec(`chromium-browser ${process.env.APP_ORIGIN} --start-fullscreen`,
     (error, stdout, stderr) => {


### PR DESCRIPTION
This PR brings back the automatic key press that confirms the HTTP Auth.

It is not necessary to include the credentials because they are save din the browser.

We increase the timeout for pressing return programmatically, because sometimes the deployed web app needs some time to wake up (seems to be a thing on Fly.io)